### PR TITLE
Fix: Nearest node not wrapped in Node object

### DIFF
--- a/typesense/configuration.py
+++ b/typesense/configuration.py
@@ -32,7 +32,11 @@ class Configuration(object):
                 Node(node_dict['host'], node_dict['port'], node_dict.get('path', ''), node_dict['protocol'])
             )
 
-        self.nearest_node = config_dict.get('nearest_node', None)
+        nearest_node = config_dict.get('nearest_node', None)
+        if nearest_node:
+            self.nearest_node = Node(nearest_node['host'], nearest_node['port'], nearest_node.get('path', ''), nearest_node['protocol'])
+        else:
+            self.nearest_node = None
 
         self.api_key = config_dict.get('api_key', '')
         self.connection_timeout_seconds = config_dict.get('connection_timeout_seconds', 3.0)


### PR DESCRIPTION
## Change Summary
If the nearest node config option is set the following error occurs:

```
Traceback (most recent call last):
  File "[...]/scratches/scratch_160.py", line 17, in <module>
    typesense_client = typesense.Client(
  File "[...]/python3.8/site-packages/typesense/client.py", line 14, in __init__
    self.api_call = ApiCall(self.config)
  File "[...]/python3.8/site-packages/typesense/api_call.py", line 22, in __init__
    self._initialize_nodes()
  File "[...]/python3.8/site-packages/typesense/api_call.py", line 26, in _initialize_nodes
    self.set_node_healthcheck(self.config.nearest_node, True)
  File "[...]/python3.8/site-packages/typesense/api_call.py", line 132, in set_node_healthcheck
    node.healthy = is_healthy
AttributeError: 'dict' object has no attribute 'healthy'
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
