### PR TITLE
Use library logger instead of root logger

### DIFF
--- a/typesense/__init__.py
+++ b/typesense/__init__.py
@@ -1,4 +1,1 @@
 from .client import Client  # NOQA
-import logging
-
-logging.basicConfig(level=logging.WARN)

--- a/typesense/api_call.py
+++ b/typesense/api_call.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import json
 import time
 
@@ -8,8 +7,7 @@ from .exceptions import (HTTPStatus0Error, ObjectAlreadyExists,
                          ObjectNotFound, ObjectUnprocessable,
                          RequestMalformed, RequestUnauthorized, RequestForbidden,
                          ServerError, ServiceUnavailable, TypesenseClientError)
-
-logger = logging.getLogger(__name__)
+from .logger import logger
 
 
 class ApiCall(object):

--- a/typesense/configuration.py
+++ b/typesense/configuration.py
@@ -1,8 +1,5 @@
-import logging
-
 from .exceptions import ConfigError
-
-logger = logging.getLogger(__name__)
+from .logger import logger
 
 
 class Node(object):

--- a/typesense/documents.py
+++ b/typesense/documents.py
@@ -1,9 +1,7 @@
 import json
-import logging
 
 from .document import Document
-
-logger = logging.getLogger(__name__)
+from .logger import logger
 
 
 class Documents(object):

--- a/typesense/logger.py
+++ b/typesense/logger.py
@@ -1,3 +1,4 @@
 import logging
 
 logger = logging.getLogger("typesense")
+logger.setLevel(logging.WARN)

--- a/typesense/logger.py
+++ b/typesense/logger.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("typesense")


### PR DESCRIPTION
## Change Summary
This library configures the python root logger, which may lead to  issues when importing the library in a project (see https://github.com/typesense/typesense-python/issues/16).

This is fixed by introducing a library level logger with name `typesense`. This follows pythons [recommendations for libraries](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
