### PR TITLE
Include invalid json string response when failing to import documents

### DIFF
--- a/typesense/documents.py
+++ b/typesense/documents.py
@@ -81,7 +81,7 @@ class Documents(object):
                     try:
                         res_obj_json = json.loads(res_obj_str)
                     except json.JSONDecodeError as e:
-                        raise TypesenseClientError("Invalid response") from e
+                        raise TypesenseClientError(f"Invalid response - {res_obj_str}") from e
                     response_objs.append(res_obj_json)
 
             return response_objs


### PR DESCRIPTION
## Change Summary
We are currently occasionally seeing TypesenseClientErrors when importing documents into our Typesense HA cluster. 
This change enables us to see the invalid json string we are getting from the Typesense response.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
