### PR TITLE
Throw error if search parameters are not all strings

### DIFF
--- a/typesense/documents.py
+++ b/typesense/documents.py
@@ -4,6 +4,7 @@ from typesense.exceptions import TypesenseClientError
 
 from .document import Document
 from .logger import logger
+from .validation import validate_query_by
 from collections.abc import Iterable
 
 class Documents(object):
@@ -94,7 +95,8 @@ class Documents(object):
         return api_response
 
     def search(self, search_parameters):
+        validate_query_by(search_parameters)
         return self.api_call.get(self._endpoint_path('search'), search_parameters)
 
     def delete(self, params=None):
-      return self.api_call.delete(self._endpoint_path(), params)
+        return self.api_call.delete(self._endpoint_path(), params)

--- a/typesense/documents.py
+++ b/typesense/documents.py
@@ -4,7 +4,7 @@ from typesense.exceptions import TypesenseClientError
 
 from .document import Document
 from .logger import logger
-from .validation import validate_query_by
+from .validation import validate_search
 from collections.abc import Iterable
 
 class Documents(object):
@@ -95,7 +95,7 @@ class Documents(object):
         return api_response
 
     def search(self, search_parameters):
-        validate_query_by(search_parameters)
+        validate_search(search_parameters)
         return self.api_call.get(self._endpoint_path('search'), search_parameters)
 
     def delete(self, params=None):

--- a/typesense/documents.py
+++ b/typesense/documents.py
@@ -5,6 +5,7 @@ from typesense.exceptions import TypesenseClientError
 from .document import Document
 from .logger import logger
 from .validation import validate_search
+from .preprocess import stringify_search_params
 from collections.abc import Iterable
 
 class Documents(object):
@@ -95,8 +96,9 @@ class Documents(object):
         return api_response
 
     def search(self, search_parameters):
-        validate_search(search_parameters)
-        return self.api_call.get(self._endpoint_path('search'), search_parameters)
+        stringified_search_params = stringify_search_params(search_parameters)
+        validate_search(stringified_search_params)
+        return self.api_call.get(self._endpoint_path('search'), stringified_search_params)
 
     def delete(self, params=None):
         return self.api_call.delete(self._endpoint_path(), params)

--- a/typesense/exceptions.py
+++ b/typesense/exceptions.py
@@ -45,3 +45,7 @@ class ServiceUnavailable(TypesenseClientError):
 
 class HTTPStatus0Error(TypesenseClientError):
     pass
+
+
+class InvalidParameter(TypesenseClientError):
+    pass

--- a/typesense/preprocess.py
+++ b/typesense/preprocess.py
@@ -1,0 +1,8 @@
+def stringify_search_params(params):
+    return {key:stringify(val) for key, val in params.items()}
+
+def stringify(val):
+    if isinstance(val, bool) or isinstance(val, int):
+        return str(val).lower()
+    else:
+        return val

--- a/typesense/validation.py
+++ b/typesense/validation.py
@@ -1,6 +1,7 @@
 from typesense.exceptions import InvalidParameter
 
 
-def validate_query_by(params):
-    if "query_by" in params and type(params["query_by"]) is not str:
-        raise InvalidParameter(f"'query_by' field expected a string but was given {type(params['query_by']).__name__}")
+def validate_search(params):
+    for key in params:
+        if type(params[key]) is not str:
+            raise InvalidParameter(f"'{key}' field expected a string but was given {type(params[key]).__name__}")

--- a/typesense/validation.py
+++ b/typesense/validation.py
@@ -3,5 +3,5 @@ from typesense.exceptions import InvalidParameter
 
 def validate_search(params):
     for key in params:
-        if type(params[key]) is not str:
+        if not isinstance(params[key], str):
             raise InvalidParameter(f"'{key}' field expected a string but was given {type(params[key]).__name__}")

--- a/typesense/validation.py
+++ b/typesense/validation.py
@@ -1,0 +1,6 @@
+from typesense.exceptions import InvalidParameter
+
+
+def validate_query_by(params):
+    if "query_by" in params and type(params["query_by"]) is not str:
+        raise InvalidParameter(f"'query_by' field expected a string but was given {type(params['query_by']).__name__}")


### PR DESCRIPTION
## Change Summary
When query_by is passed an array of strings it takes the last string only. This now throws an InvalidParameter error, so only strings can be used. This is to avoid unexpected behaviour and improve usability.

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
