### PR TITLE
Fix: API client to normalize only booleans not integers

### DIFF
--- a/src/typesense/api_call.py
+++ b/src/typesense/api_call.py
@@ -136,9 +136,9 @@ class ApiCall(object):
     @staticmethod
     def normalize_params(params):
         for key in params.keys():
-            if params[key] == True:
+            if isinstance(params[key], bool) and params[key]:
                 params[key] = 'true'
-            elif params[key] == False:
+            elif isinstance(params[key], bool) and not params[key]:
                 params[key] = 'false'
 
     def get(self, endpoint, params=None, as_json=True):


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
In `src/typesense/api_call.py` updated `normalize_params` function to normalize only when the value is boolean.
Reason for the change is that `api_call.py` automatically converts integer values such as `0` and `1` to string `true `or `false`. Hence, querying by `page=1` raises error.

Related  #41 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
