### PR TITLE
fix: node initialization using a url string

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,13 @@
-requests==2.22.0
+certifi==2024.7.4
+chardet==3.0.4
+charset-normalizer==3.3.2
+idna==2.8
+iniconfig==2.0.0
+mypy==1.11.0
+mypy-extensions==1.0.0
+packaging==24.1
+pluggy==1.5.0
+pytest==8.3.2
+requests==2.32.3
+typing_extensions==4.12.2
+urllib3==2.2.2

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -1,0 +1,41 @@
+import pytest
+
+from src.typesense.configuration import Node
+from src.typesense.exceptions import ConfigError
+
+
+def test_node_initialization():
+    node = Node(host="localhost", port=8108, path="/path", protocol="http")
+    assert node.host == "localhost"
+    assert node.port == 8108
+    assert node.path == "/path"
+    assert node.protocol == "http"
+    assert node.healthy is True
+
+
+def test_node_from_url():
+    node = Node.from_url("http://localhost:8108/path")
+    assert node.host == "localhost"
+    assert node.port == 8108
+    assert node.path == "/path"
+    assert node.protocol == "http"
+
+
+def test_node_from_url_missing_hostname():
+    with pytest.raises(ConfigError, match="Node URL does not contain the host name."):
+        Node.from_url("http://:8108/path")
+
+
+def test_node_from_url_missing_port():
+    with pytest.raises(ConfigError, match="Node URL does not contain the port."):
+        Node.from_url("http://localhost:/path")
+
+
+def test_node_from_url_missing_scheme():
+    with pytest.raises(ConfigError, match="Node URL does not contain the protocol."):
+        Node.from_url("//localhost:8108/path")
+
+
+def test_node_url():
+    node = Node(host="localhost", port=8108, path="/path", protocol="http")
+    assert node.url() == "http://localhost:8108/path"


### PR DESCRIPTION
## Change Summary

This pull request addresses issues with the Node class initialization in the Typesense Python SDK.  In #44, a second constructor was implemented, using a string as a url parameter. Python does not support constructor overloading. For this reason, a new Class method named `from_url()` was introduced, in order to use a string URL as the input parameter. The tests introduced  are failing with the original implementation.

# Changes

## Code Changes:

1. **In `src/typesense/configuration.py`**:
   - Removed the double-defined constructor in the `Node` class, which was causing initialization errors.
   - Added a new `from_url` class method to create `Node` instances from URLs, improving URL parsing and validation.
   - Enhanced type hints for `Node` constructor parameters, increasing type safety.
   - Updated the `Configuration` class to use the new `Node.from_url` method when creating Node instances from URLs.

2. **In `requirements.txt`**:
   - Added both mypy and pytest, serving as a static type checker and a test runner respectively
   - Updated `requests` library to version 2.22.0.

## Added Files:

1. **Added `pytest.ini`**:
   - Added the pytest configuration file, to set the Python path to the `src` directory.

2. **Added `tests/__init__.py` and `tests/node_test.py`**:
   - Added the test files for the Node class.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
