### PR TITLE
feat: Add support for additional headers in API requests

### DIFF
--- a/src/typesense/configuration.py
+++ b/src/typesense/configuration.py
@@ -74,6 +74,8 @@ class ConfigDict(typing.TypedDict):
         master_node (typing.Union[str, NodeConfigDict], deprecated): A dictionary or
             URL that represents the master node.
 
+        additional_headers (dict): Additional headers to include in the request.
+
         read_replica_nodes (list[typing.Union[str, NodeConfigDict]], deprecated): A list of
             dictionaries or URLs that represent the read replica nodes.
     """
@@ -87,6 +89,7 @@ class ConfigDict(typing.TypedDict):
     verify: typing.NotRequired[bool]
     timeout_seconds: typing.NotRequired[int]  # deprecated
     master_node: typing.NotRequired[typing.Union[str, NodeConfigDict]]  # deprecated
+    additional_headers: typing.NotRequired[typing.Dict[str, str]]
     read_replica_nodes: typing.NotRequired[
         typing.List[typing.Union[str, NodeConfigDict]]
     ]  # deprecated
@@ -213,6 +216,7 @@ class Configuration:
             60,
         )
         self.verify = config_dict.get("verify", True)
+        self.additional_headers = config_dict.get("additional_headers", {})
 
     def _handle_nearest_node(
         self,

--- a/src/typesense/request_handler.py
+++ b/src/typesense/request_handler.py
@@ -204,7 +204,11 @@ class RequestHandler:
         Raises:
             TypesenseClientError: If the API returns an error response.
         """
-        headers = {self.api_key_header_name: self.config.api_key}
+        headers = {
+            self.api_key_header_name: self.config.api_key,
+        }
+        headers.update(self.config.additional_headers)
+
         kwargs.setdefault("headers", {}).update(headers)
         kwargs.setdefault("timeout", self.config.connection_timeout_seconds)
         kwargs.setdefault("verify", self.config.verify)

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -66,6 +66,7 @@ def test_configuration_explicit() -> None:
         "num_retries": 5,
         "retry_interval_seconds": 2.0,
         "verify": False,
+        "additional_headers": {"X-Test": "test", "X-Test2": "test2"},
     }
 
     configuration = Configuration(config)
@@ -82,6 +83,7 @@ def test_configuration_explicit() -> None:
         "num_retries": 5,
         "retry_interval_seconds": 2.0,
         "verify": False,
+        "additional_headers": {"X-Test": "test", "X-Test2": "test2"},
     }
 
     assert_to_contain_object(configuration, expected)


### PR DESCRIPTION
# What is this?

This pull request introduces the ability to include custom headers in API requests to Typesense. This enhancement provides greater flexibility for users who need to send specific headers with their requests, such as for authentication or custom metadata. This tries to address the feature request discussed on #54 

# Changes

## Added Features:

1. **New configuration option in `configuration.py`**:
   - `additional_headers`: A dictionary to specify custom headers to be included in all API requests.

## Code Changes:

1. **In `src/typesense/configuration.py`**:
   - Added `additional_headers` to the `ConfigDict` type definition.
   - Updated the `Configuration` class to include an `additional_headers` attribute, initialized from the config dictionary.

2. **In `src/typesense/request_handler.py`**:
   - Modified the `RequestHandler._execute_request` method to include the `additional_headers` from the configuration in all outgoing requests.

3. **In `tests/api_call_test.py`**:
   - Added a new test case `test_additional_headers` to verify that additional headers from the configuration are correctly included in API requests.

4. **In `tests/configuration_test.py`**:
   - Updated the `test_configuration_explicit` test to include `additional_headers` in the configuration and expected output.

## Documentation Updates:

1. **In `src/typesense/configuration.py`**:
   - Added documentation for the new `additional_headers` configuration option in the `ConfigDict` class docstring.
  
##PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
