### PR TITLE
fix(api-call): remove unpack and use typeddict directly

### DIFF
--- a/src/typesense/api_call.py
+++ b/src/typesense/api_call.py
@@ -334,7 +334,7 @@ class ApiCall:
         as_json: typing.Literal[True],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> TEntityDict:
         """
         Execute a request to the Typesense API with retry logic.
@@ -373,7 +373,7 @@ class ApiCall:
         as_json: typing.Literal[False],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> str:
         """
         Execute a request to the Typesense API with retry logic.
@@ -411,7 +411,7 @@ class ApiCall:
         as_json: typing.Union[typing.Literal[True], typing.Literal[False]] = True,
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> typing.Union[TEntityDict, str]:
         """
         Execute a request to the Typesense API with retry logic.
@@ -493,7 +493,7 @@ class ApiCall:
     def _prepare_request_params(
         self,
         endpoint: str,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> typing.Tuple[Node, str, SessionFunctionKwargs[TParams, TBody]]:
         node = self.node_manager.get_node()
         url = node.url() + endpoint


### PR DESCRIPTION
## Change Summary
Fix potential mypy error for unpacking a non-typedDict kwarg
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
