### PR TITLE
Add CI workflows for testing, linting and publishing to PyPI by tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Publish Package to PyPI
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+        cache: 'pip'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/dev.txt
+    
+    - name: Run tests (excluding OpenAI)
+      run: coverage run -m pytest -m "not open_ai"
+      
+    - name: Show coverage report
+      run: coverage report
+  build-n-publish:
+    name: Build and Publish
+    needs: tests
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/typesense
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+        cache: pip
+        
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: |
+        rm -rf dist/
+        python -m build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: true

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,0 +1,57 @@
+name: Test and Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    services:
+      typesense:
+        image: typesense/typesense:27.1
+        ports:
+          - 8108:8108
+        volumes:
+          - /tmp/typesense-data:/data
+          - /tmp/typesense-analytics:/analytics
+        env:
+          TYPESENSE_API_KEY: xyz
+          TYPESENSE_DATA_DIR: /data
+          TYPESENSE_ENABLE_CORS: true
+          TYPESENSE_ANALYTICS_DIR: /analytics
+          TYPESENSE_ENABLE_SEARCH_ANALYTICS: true
+
+    steps:
+    - name: Wait for Typesense
+      run: |
+        timeout 20 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:8108/health)" != "200" ]]; do sleep 1; done' || false
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/dev.txt
+
+    - name: Lint with Flake8
+      run: |
+        flake8 src/typesense
+
+    - name: Check types with mypy
+      run: |
+        mypy src/typesense
+
+    - name: Run tests and coverage (excluding OpenAI)
+      run: |
+        coverage run -m pytest -m "not open_ai"

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -2,9 +2,9 @@ name: Test and Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   quality:

--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-rm -rf dist/*
-python3 -m build
-twine upload dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ docstring-style = sphinx
 max-complexity = 6
 
 # # Excluding some directories:
-exclude = .git,__pycache__,venv,.eggs,*.egg
+exclude = .git,__pycache__,venv,.eggs,*.egg,src/typesense/__init__.py
 ignore = Q000, WPS602, WPS432, WPS305, WPS221, WPS230, WPS234, WPS433, WPS440, W503, WPS331, WPS306, WPS237, WPS202, RST301, RST306, WPS214, WPS235, WPS226, WPS337, WPS320, F821, WPS201
 per-file-ignores = 
   tests/*.py: S101, WPS226, WPS118, WPS202, WPS204, WPS218, WPS211, WPS604, WPS431, WPS210, WPS201, WPS437


### PR DESCRIPTION
## Change Summary

## What is this?

This pull request introduces a new GitHub Actions workflow for publishing the Python package to PyPI when a new release tag is pushed. This new workflow aims to streamline the release process and ensure that the package is built and published correctly.

## Changes

### Added Features:
1. **New Workflow in `.github/workflows/release.yml`**:
  - The `release.yml` workflow is triggered when a new Git tag starting with `v` is pushed to the repository.
  - It consists of two jobs:
    - `tests`: Runs the test suite (excluding OpenAI tests) and reports the test coverage.
    - `build-n-publish`: Builds the Python package and publishes it to PyPI using the `pypa/gh-action-pypi-publish` action.
  - The workflow checks out the repository, sets up the Python environment, installs the necessary dependencies, and runs the required commands to build and publish the package.
  - The `attestations` option is enabled for the PyPI publish step to ensure build provenance.
  - Added a new GitHub Actions workflow file to handle the release process.
  - The workflow consists of two jobs: `tests` and `build-n-publish`.
  - The `tests` job runs the test suite and reports the coverage.
  - The `build-n-publish` job builds the package and publishes it to PyPI.
2. **New Workflow in `.github/workflows/test-and-lint.yml`**:
 - The `test-and-lint.yml` workflow is triggered on both push and pull request events to the `master` branch.
 - It runs a `quality` job that tests the codebase against multiple Python versions (3.8, 3.9, 3.10, 3.11, 3.12).
 - The job sets up a Typesense service as a dependency, waits for it to be ready, and then runs the following tasks:
    - Installs the project's development dependencies.
    - Lints the code using Flake8.
    - Checks the type annotations using mypy.
    - Runs the test suite (excluding OpenAI tests) and reports the coverage.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
