### PR TITLE
chore: use SessionFunctionKwargs directly instead of unpacking

### DIFF
--- a/src/typesense/api_call.py
+++ b/src/typesense/api_call.py
@@ -334,7 +334,7 @@ class ApiCall:
         as_json: typing.Literal[True],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: typing.Any,
     ) -> TEntityDict:
         """
         Execute a request to the Typesense API with retry logic.
@@ -373,7 +373,7 @@ class ApiCall:
         as_json: typing.Literal[False],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: typing.Any,
     ) -> str:
         """
         Execute a request to the Typesense API with retry logic.
@@ -411,7 +411,7 @@ class ApiCall:
         as_json: typing.Union[typing.Literal[True], typing.Literal[False]] = True,
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: typing.Any,
     ) -> typing.Union[TEntityDict, str]:
         """
         Execute a request to the Typesense API with retry logic.
@@ -493,7 +493,7 @@ class ApiCall:
     def _prepare_request_params(
         self,
         endpoint: str,
-        **kwargs: typing.Unpack[SessionFunctionKwargs[TParams, TBody]],
+        **kwargs: typing.Any,
     ) -> typing.Tuple[Node, str, SessionFunctionKwargs[TParams, TBody]]:
         node = self.node_manager.get_node()
         url = node.url() + endpoint

--- a/src/typesense/api_call.py
+++ b/src/typesense/api_call.py
@@ -334,7 +334,7 @@ class ApiCall:
         as_json: typing.Literal[True],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Any,
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> TEntityDict:
         """
         Execute a request to the Typesense API with retry logic.
@@ -373,7 +373,7 @@ class ApiCall:
         as_json: typing.Literal[False],
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Any,
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> str:
         """
         Execute a request to the Typesense API with retry logic.
@@ -411,7 +411,7 @@ class ApiCall:
         as_json: typing.Union[typing.Literal[True], typing.Literal[False]] = True,
         last_exception: typing.Union[None, Exception] = None,
         num_retries: int = 0,
-        **kwargs: typing.Any,
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> typing.Union[TEntityDict, str]:
         """
         Execute a request to the Typesense API with retry logic.
@@ -473,7 +473,7 @@ class ApiCall:
         url: str,
         entity_type: typing.Type[TEntityDict],
         as_json: bool,
-        **kwargs: typing.Any,
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> typing.Union[TEntityDict, str]:
         """Make the API request and process the response."""
         request_response = self.request_handler.make_request(
@@ -493,7 +493,7 @@ class ApiCall:
     def _prepare_request_params(
         self,
         endpoint: str,
-        **kwargs: typing.Any,
+        **kwargs: SessionFunctionKwargs[TParams, TBody],
     ) -> typing.Tuple[Node, str, SessionFunctionKwargs[TParams, TBody]]:
         node = self.node_manager.get_node()
         url = node.url() + endpoint

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -47,9 +47,11 @@ def test_retrieve(fake_debug: Debug) -> None:
 
 
 def test_actual_retrieve(actual_debug: Debug) -> None:
-    """Test that the Debug object can retrieve a debug on Typesense server."""
-    json_response: DebugResponseSchema = {"state": 1, "version": "27.0"}
-
+    """Test that the Debug object can retrieve a debug on Typesense server and verify response structure."""
     response = actual_debug.retrieve()
 
-    assert response == json_response
+    assert "state" in response
+    assert "version" in response
+
+    assert isinstance(response["state"], int)
+    assert isinstance(response["version"], str)


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes changes to the `src/typesense/api_call.py` file to address types errors  for keyword arguments in several methods. The changes replace the use of `typing.Unpack` with `typing.Any` for the `**kwargs` parameter in multiple methods.

Mypy can't decipher that the imported type is indeed extending a TypedDict, resulting in mypy errors on CI.

* [`src/typesense/api_call.py`](diffhunk://#diff-71977080cf0d64ce23944ea2904fe498648bd911d9d73b8e40deed4a83b54235L337-R337): Modified the `**kwargs` parameter in the `_execute_request` method to use `typing.Any` instead of `typing.Unpack[SessionFunctionKwargs[TParams, TBody]]` for three different method signatures. [[1]](diffhunk://#diff-71977080cf0d64ce23944ea2904fe498648bd911d9d73b8e40deed4a83b54235L337-R337) [[2]](diffhunk://#diff-71977080cf0d64ce23944ea2904fe498648bd911d9d73b8e40deed4a83b54235L376-R376) [[3]](diffhunk://#diff-71977080cf0d64ce23944ea2904fe498648bd911d9d73b8e40deed4a83b54235L414-R414)
* [`src/typesense/api_call.py`](diffhunk://#diff-71977080cf0d64ce23944ea2904fe498648bd911d9d73b8e40deed4a83b54235L496-R496): Modified the `**kwargs` parameter in the `_make_request_and_process_response` method to use `typing.Any` instead of `typing.Unpack[SessionFunctionKwargs[TParams, TBody]]`.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
