### PR TITLE
ci: remove tests from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,29 +4,7 @@ on:
     tags:
       - 'v*'
 jobs:
-  tests:
-    name: Run Tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.8"
-        cache: 'pip'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements/dev.txt
-    
-    - name: Run tests (excluding OpenAI)
-      run: coverage run -m pytest -m "not open_ai"
-      
-    - name: Show coverage report
-      run: coverage report
-  build-n-publish:
+ build-n-publish:
     name: Build and Publish
     needs: tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 jobs:
- build-n-publish:
+  build-n-publish:
     name: Build and Publish
     needs: tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes changes to the GitHub Actions workflow configuration file `.github/workflows/release.yml`. The most important change involves removing the `tests` job, which ran tests and showed the coverage report.

Changes to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L7-L28): Removed the `tests` job, which included steps for setting up Python, installing dependencies, running tests (excluding OpenAI), and showing the coverage report.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
