### PR TITLE
feat(document): add `ignore_not_found` option to delete method

### DIFF
--- a/src/typesense/document.py
+++ b/src/typesense/document.py
@@ -22,7 +22,11 @@ versions through the use of the typing_extensions library.
 import sys
 
 from typesense.api_call import ApiCall
-from typesense.types.document import DirtyValuesParameters, DocumentSchema
+from typesense.types.document import (
+    DeleteSingleDocumentParameters,
+    DirtyValuesParameters,
+    DocumentSchema,
+)
 
 if sys.version_info >= (3, 11):
     import typing
@@ -101,7 +105,10 @@ class Document(typing.Generic[TDoc]):
         )
         return typing.cast(TDoc, response)
 
-    def delete(self) -> TDoc:
+    def delete(
+        self,
+        delete_parameters: typing.Union[DeleteSingleDocumentParameters, None] = None,
+    ) -> TDoc:
         """
         Delete this specific document.
 
@@ -111,6 +118,7 @@ class Document(typing.Generic[TDoc]):
         response: TDoc = self.api_call.delete(
             self._endpoint_path,
             entity_type=typing.Dict[str, str],
+            params=delete_parameters,
         )
         return response
 

--- a/src/typesense/types/document.py
+++ b/src/typesense/types/document.py
@@ -827,6 +827,17 @@ class SearchResponse(typing.Generic[TDoc], typing.TypedDict):
     conversation: typing.NotRequired[Conversation]
 
 
+class DeleteSingleDocumentParameters(typing.TypedDict):
+    """
+    Parameters for deleting a single document.
+
+    Attributes:
+      ignore_not_found (bool): Ignore not found documents.
+    """
+
+    ignore_not_found: typing.NotRequired[bool]
+
+
 class DeleteQueryParameters(typing.TypedDict):
     """
     Parameters for deleting documents.

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import requests_mock
 
 from tests.fixtures.document_fixtures import Companies
@@ -13,6 +14,7 @@ from tests.utils.object_assertions import (
 from typesense.api_call import ApiCall
 from typesense.document import Document
 from typesense.documents import Documents
+from typesense.exceptions import ObjectNotFound
 
 
 def test_init(fake_api_call: ApiCall) -> None:
@@ -133,3 +135,28 @@ def test_actual_delete(
         "company_name": "Company",
         "num_employees": 10,
     }
+
+
+def test_actual_delete_non_existent(
+    actual_documents: Documents,
+    delete_all: None,
+    create_collection: None,
+    create_document: None,
+) -> None:
+    """Test that the Document object can delete an document from Typesense Server."""
+    with pytest.raises(ObjectNotFound):
+        actual_documents["1"].delete()
+
+
+def test_actual_delete_non_existent_ignore_not_found(
+    actual_documents: Documents,
+    delete_all: None,
+    create_collection: None,
+    create_document: None,
+) -> None:
+    """Test that the Document object can delete an document from Typesense Server."""
+    response = actual_documents["1"].delete(
+        delete_parameters={"ignore_not_found": True},
+    )
+
+    assert response == {"id": "1"}


### PR DESCRIPTION
### TLDR
Closes #65 

## Change Summary
This pull request includes changes to the `typesense` library to enhance document deletion functionality and improve testing coverage. The most important changes include adding parameters for deleting a single document, updating the delete method, and adding new tests for the delete functionality.

Enhancements to document deletion:

* [`src/typesense/document.py`](diffhunk://#diff-581d9d87a54370e082ff8aea644b20922125405f1ac65f178bc7d85a1a357a52L25-R29): Imported `DeleteSingleDocumentParameters` and updated the `delete` method to accept optional delete parameters. [[1]](diffhunk://#diff-581d9d87a54370e082ff8aea644b20922125405f1ac65f178bc7d85a1a357a52L25-R29) [[2]](diffhunk://#diff-581d9d87a54370e082ff8aea644b20922125405f1ac65f178bc7d85a1a357a52L104-R111) [[3]](diffhunk://#diff-581d9d87a54370e082ff8aea644b20922125405f1ac65f178bc7d85a1a357a52R121)
* [`src/typesense/types/document.py`](diffhunk://#diff-f311903c2ec67750b4d9d2f62aeaa14cf135dbc649993145b5e1dd820240e37aR830-R840): Added `DeleteSingleDocumentParameters` class to define parameters for deleting a single document.

Improvements to testing:

* [`tests/document_test.py`](diffhunk://#diff-c0111cc0aaf733a15e18807bf7f3a09f8affc773e165a8fa26b526c503fa9d2bR5): Added `pytest` import and new test cases to verify the delete functionality, including handling non-existent documents and the `ignore_not_found` parameter. [[1]](diffhunk://#diff-c0111cc0aaf733a15e18807bf7f3a09f8affc773e165a8fa26b526c503fa9d2bR5) [[2]](diffhunk://#diff-c0111cc0aaf733a15e18807bf7f3a09f8affc773e165a8fa26b526c503fa9d2bR17) [[3]](diffhunk://#diff-c0111cc0aaf733a15e18807bf7f3a09f8affc773e165a8fa26b526c503fa9d2bR138-R162)


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
