### PR TITLE
chore: bundle typing extensions by default

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 requests = "*"
+typing-extensions = {version = "*", markers = "python_version < '3.11'"}
 
 [dev-packages]
 mypy = "*"
@@ -17,7 +18,6 @@ pytest-mock = "*"
 requests-mock = "*"
 python-dotenv = "*"
 types-requests = "*"
-typing-extensions = {version = "*", markers = "python_version < '3.11'"}
 faker = "*"
 
 [requires]


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes changes to the `Pipfile` to update package dependencies. The most important changes involve the addition and removal of the `typing-extensions` package.

Dependency updates:

* Added `typing-extensions` to the `[packages]` section with a version constraint for Python versions below 3.11.
* Removed `typing-extensions` from the `[dev-packages]` section.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
