### PR TITLE
fix: add base document write parameters to the import type alias

### DIFF
--- a/src/typesense/types/document.py
+++ b/src/typesense/types/document.py
@@ -300,6 +300,7 @@ class DocumentImportParametersReturnDocAndId(DocumentWriteParameters):
 
 
 DocumentImportParameters: typing.TypeAlias = typing.Union[
+    DocumentWriteParameters,
     DocumentImportParametersReturnId,
     DocumentImportParametersReturnDoc,
     DocumentImportParametersReturnDocAndId,


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This pull request includes a change to the `src/typesense/types/document.py` file to enhance the type alias definition for `DocumentImportParameters`.

Enhancements to type alias definition:

* [`src/typesense/types/document.py`](diffhunk://#diff-f311903c2ec67750b4d9d2f62aeaa14cf135dbc649993145b5e1dd820240e37aR303): Added `DocumentWriteParameters` to the `DocumentImportParameters` type alias to include it as a valid option.

Closes #74.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
