### PR TITLE
fix(api): improve error handling for invalid JSON responses

### DIFF
--- a/src/typesense/request_handler.py
+++ b/src/typesense/request_handler.py
@@ -260,8 +260,11 @@ class RequestHandler:
         """
         content_type = response.headers.get("Content-Type", "")
         if content_type.startswith("application/json"):
-            err_message: str = response.json().get("message", "API error.")
-            return err_message
+            try:
+                err_message: str = response.json().get("message", "API error.")
+                return err_message
+            except requests.exceptions.JSONDecodeError:
+                return f"API error: Invalid JSON response: {response.text}"
         return "API error."
 
     @staticmethod

--- a/src/typesense/request_handler.py
+++ b/src/typesense/request_handler.py
@@ -261,8 +261,7 @@ class RequestHandler:
         content_type = response.headers.get("Content-Type", "")
         if content_type.startswith("application/json"):
             try:
-                err_message: str = response.json().get("message", "API error.")
-                return err_message
+                return typing.cast(str, response.json().get("message", "API error."))
             except requests.exceptions.JSONDecodeError:
                 return f"API error: Invalid JSON response: {response.text}"
         return "API error."


### PR DESCRIPTION
## Change Summary
Closes #82 
- enhance `_get_error_message` to handle JSON decode errors
- add detailed error message including the invalid response text
- add tests covering valid JSON, invalid JSON, and non-JSON responses


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
