### PR TITLE
feat(collections): add `__contains__` method for collection existence

### DIFF
--- a/src/typesense/collections.py
+++ b/src/typesense/collections.py
@@ -57,6 +57,22 @@ class Collections(typing.Generic[TDoc]):
         self.api_call = api_call
         self.collections: typing.Dict[str, Collection[TDoc]] = {}
 
+    def __contains__(self, collection_name: str) -> bool:
+        """
+        Check if a collection exists in Typesense.
+
+        Args:
+            collection_name (str): The name of the collection to check.
+
+        Returns:
+            bool: True if the collection exists, False otherwise.
+        """
+        try:
+            all_collections = self.retrieve()
+        except Exception:
+            return False
+        return any(coll["name"] == collection_name for coll in all_collections)
+
     def __getitem__(self, collection_name: str) -> Collection[TDoc]:
         """
         Get or create a Collection instance for a given collection name.

--- a/src/typesense/collections.py
+++ b/src/typesense/collections.py
@@ -61,17 +61,28 @@ class Collections(typing.Generic[TDoc]):
         """
         Check if a collection exists in Typesense.
 
+        This method tries to retrieve the specified collection to check for its existence,
+        utilizing the Collection.retrieve() method but without caching non-existent collections.
+
         Args:
             collection_name (str): The name of the collection to check.
 
         Returns:
             bool: True if the collection exists, False otherwise.
         """
+        if collection_name in self.collections:
+            try:
+                self.collections[collection_name].retrieve()
+                return True
+            except Exception:
+                self.collections.pop(collection_name, None)
+                return False
+        
         try:
-            all_collections = self.retrieve()
+            Collection(self.api_call, collection_name).retrieve()
+            return True
         except Exception:
             return False
-        return any(coll["name"] == collection_name for coll in all_collections)
 
     def __getitem__(self, collection_name: str) -> Collection[TDoc]:
         """

--- a/src/typesense/collections.py
+++ b/src/typesense/collections.py
@@ -71,14 +71,15 @@ class Collections(typing.Generic[TDoc]):
             bool: True if the collection exists, False otherwise.
         """
         if collection_name in self.collections:
-            try:
-                self.collections[collection_name].retrieve()
+            try:  # noqa: WPS229, WPS529
+
+                self.collections[collection_name].retrieve()  # noqa: WPS529
                 return True
             except Exception:
                 self.collections.pop(collection_name, None)
                 return False
-        
-        try:
+
+        try:  # noqa: WPS229, WPS529
             Collection(self.api_call, collection_name).retrieve()
             return True
         except Exception:

--- a/tests/collections_test.py
+++ b/tests/collections_test.py
@@ -306,3 +306,5 @@ def test_actual_contains(
 
     # Test for non-existing collection
     assert "non_existent_collection" not in actual_collections
+    # Test again
+    assert "non_existent_collection" not in actual_collections

--- a/tests/collections_test.py
+++ b/tests/collections_test.py
@@ -293,3 +293,16 @@ def test_actual_retrieve(
 
     response[0].pop("created_at")
     assert response == expected
+
+
+def test_actual_contains(
+    actual_collections: Collections,
+    delete_all: None,
+    create_collection: None,
+) -> None:
+    """Test that the Collections object can check if a collection exists in Typesense."""
+    # Test for existing collection
+    assert "companies" in actual_collections
+
+    # Test for non-existing collection
+    assert "non_existent_collection" not in actual_collections


### PR DESCRIPTION


## Change Summary
Closes #53 
- implement `__contains__` method to check if collection exists
- enable use of `in` operator with collection names
- handle exceptions gracefully when unable to retrieve collections

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
