### PR TITLE
feat(document): add parameter support to document retrieval

### DIFF
--- a/src/typesense/document.py
+++ b/src/typesense/document.py
@@ -26,6 +26,7 @@ from typesense.types.document import (
     DeleteSingleDocumentParameters,
     DirtyValuesParameters,
     DocumentSchema,
+    RetrieveParameters,
 )
 
 if sys.version_info >= (3, 11):
@@ -67,7 +68,7 @@ class Document(typing.Generic[TDoc]):
         self.collection_name = collection_name
         self.document_id = document_id
 
-    def retrieve(self) -> TDoc:
+    def retrieve(self, params: RetrieveParameters) -> TDoc:
         """
         Retrieve this specific document.
 
@@ -78,6 +79,7 @@ class Document(typing.Generic[TDoc]):
             endpoint=self._endpoint_path,
             entity_type=typing.Dict[str, str],
             as_json=True,
+            params=params,
         )
         return response
 

--- a/src/typesense/document.py
+++ b/src/typesense/document.py
@@ -68,7 +68,10 @@ class Document(typing.Generic[TDoc]):
         self.collection_name = collection_name
         self.document_id = document_id
 
-    def retrieve(self, params: RetrieveParameters) -> TDoc:
+    def retrieve(
+        self,
+        retrieve_parameters: typing.Union[RetrieveParameters, None] = None,
+    ) -> TDoc:
         """
         Retrieve this specific document.
 
@@ -79,7 +82,7 @@ class Document(typing.Generic[TDoc]):
             endpoint=self._endpoint_path,
             entity_type=typing.Dict[str, str],
             as_json=True,
-            params=params,
+            params=retrieve_parameters,
         )
         return response
 

--- a/src/typesense/types/document.py
+++ b/src/typesense/types/document.py
@@ -889,3 +889,16 @@ class DeleteResponse(typing.TypedDict):
     """
 
     num_deleted: int
+
+
+class RetrieveParameters(typing.TypedDict):
+    """
+    Parameters for retrieving documents.
+
+    Attributes:
+      include_fields (str): Fields to include in the retrieved documents.
+      exclude_fields (str): Fields to exclude from the retrieved documents.
+    """
+
+    include_fields: typing.NotRequired[typing.Union[str, typing.List[str]]]
+    exclude_fields: typing.NotRequired[typing.Union[str, typing.List[str]]]


### PR DESCRIPTION
## Change Summary

- add `params` parameter to `Document.retrieve()` method
- create new `RetrieveParameters` typed dictionary
- support including/excluding fields when retrieving documents


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
