### PR TITLE
Fix: union in multisearch

### DIFF
--- a/src/typesense/multi_search.py
+++ b/src/typesense/multi_search.py
@@ -83,7 +83,10 @@ class MultiSearch:
             stringify_search_params(search_params)
             for search_params in search_queries.get("searches")
         ]
-        search_body = {"searches": stringified_search_params}
+        search_body = {
+            "searches": stringified_search_params,
+            "union": search_queries.get("union", False),
+        }
         response: MultiSearchResponse = self.api_call.post(
             MultiSearch.resource_path,
             body=search_body,

--- a/tests/multi_search_test.py
+++ b/tests/multi_search_test.py
@@ -106,6 +106,51 @@ def test_multi_search_multiple_searches(
         )
 
 
+def test_multi_search_union(
+    actual_multi_search: MultiSearch,
+    actual_api_call: ApiCall,
+    delete_all: None,
+    create_collection: None,
+    create_document: None,
+) -> None:
+    """Test that the MultiSearch object can perform multiple searches."""
+    request_params: MultiSearchRequestSchema = {
+        "union": True,
+        "searches": [
+            {"q": "com", "query_by": "company_name", "collection": "companies"},
+            {"q": "company", "query_by": "company_name", "collection": "companies"},
+        ],
+    }
+
+    response = actual_multi_search.perform(search_queries=request_params)
+
+    assert_to_contain_keys(
+        response,
+        [
+            "found",
+            "hits",
+            "page",
+            "out_of",
+            "union_request_params",
+            "search_time_ms",
+            "search_cutoff",
+        ],
+    )
+
+    assert_to_contain_keys(
+        response.get("hits")[0],
+        [
+            "collection",
+            "document",
+            "highlights",
+            "highlight",
+            "text_match",
+            "text_match_info",
+            "search_index",
+        ],
+    )
+
+
 def test_multi_search_array(
     actual_multi_search: MultiSearch,
     actual_api_call: ApiCall,


### PR DESCRIPTION
## Change Summary
[Fix for issue 95](https://github.com/typesense/typesense-python/issues/95)
Support "Union" in multisearch
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
