### PR TITLE
feat: add Typesense `v30.2` types for `stem` and `synonyms`

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -21,7 +21,7 @@ jobs:
         --name typesense \
         -v /tmp/typesense-data:/data \
         -v /tmp/typesense-analytics-data:/analytics-data \
-        typesense/typesense:30.0.alpha1 \
+        typesense/typesense:30.2 \
         --api-key=xyz \
         --data-dir=/data \
         --enable-search-analytics=true \

--- a/src/typesense/types/curation_set.py
+++ b/src/typesense/types/curation_set.py
@@ -33,13 +33,34 @@ class CurationRuleTagsSchema(typing.TypedDict):
     tags: typing.List[str]
 
 
-class CurationRuleQuerySchema(typing.TypedDict):
+class CurationRuleQueryBaseSchema(typing.TypedDict):
     """
-    Schema for a curation rule using query and match.
+    Schema for the base of a curation rule using query and match.
     """
 
     query: str
     match: typing.Literal["exact", "contains"]
+
+
+class CurationRuleQueryCreateSchema(CurationRuleQueryBaseSchema):
+    """
+    Schema for creating a curation rule using query and match.
+    """
+
+    stem: typing.NotRequired[bool]
+    synonyms: typing.NotRequired[bool]
+
+
+class CurationRuleQuerySchema(CurationRuleQueryBaseSchema):
+    """
+    Schema for retrieving a curation rule using query and match.
+    """
+
+    stem: typing.NotRequired[
+        bool
+    ]  # TODO: This is a bug in Typesense server upstream, so until 31.0 is
+    # released, this is staying as notrequired.
+    synonyms: typing.NotRequired[bool]
 
 
 class CurationRuleFilterBySchema(typing.TypedDict):
@@ -85,20 +106,45 @@ class CurationItemSchema(typing.TypedDict):
     metadata: typing.NotRequired[typing.Dict[str, typing.Any]]
 
 
+class CurationItemUpsertSchema(typing.TypedDict):
+    """
+    Schema for creating or updating a single curation item.
+    """
+
+    id: str
+    rule: typing.Union[
+        CurationRuleTagsSchema,
+        CurationRuleQueryCreateSchema,
+        CurationRuleFilterBySchema,
+    ]
+    includes: typing.NotRequired[typing.List[CurationIncludeSchema]]
+    excludes: typing.NotRequired[typing.List[CurationExcludeSchema]]
+    filter_by: typing.NotRequired[str]
+    sort_by: typing.NotRequired[str]
+    replace_query: typing.NotRequired[str]
+    remove_matched_tokens: typing.NotRequired[bool]
+    filter_curated_hits: typing.NotRequired[bool]
+    stop_processing: typing.NotRequired[bool]
+    effective_from_ts: typing.NotRequired[int]
+    effective_to_ts: typing.NotRequired[int]
+    metadata: typing.NotRequired[typing.Dict[str, typing.Any]]
+
+
 class CurationSetUpsertSchema(typing.TypedDict):
     """
     Payload schema to create or replace a curation set.
     """
 
-    items: typing.List[CurationItemSchema]
+    items: typing.List[CurationItemUpsertSchema]
 
 
-class CurationSetSchema(CurationSetUpsertSchema, total=False):
+class CurationSetSchema(typing.TypedDict):
     """
     Response schema for a curation set.
     """
 
-    name: typing.NotRequired[str]
+    items: typing.List[CurationItemSchema]
+    name: str
 
 
 class CurationSetsListEntrySchema(typing.TypedDict):

--- a/tests/curation_set_test.py
+++ b/tests/curation_set_test.py
@@ -1,6 +1,5 @@
 """Tests for the CurationSet class including items APIs."""
 
-
 import pytest
 
 from tests.utils.version import is_v30_or_above
@@ -62,6 +61,8 @@ def test_actual_retrieve(
                 "rule": {
                     "match": "contains",
                     "query": "shoe",
+                    "stem": False,
+                    "synonyms": False,
                 },
                 "stop_processing": True,
             },
@@ -108,6 +109,8 @@ def test_actual_list_items(
             "rule": {
                 "match": "contains",
                 "query": "shoe",
+                "stem": False,
+                "synonyms": False,
             },
             "stop_processing": True,
         },
@@ -140,6 +143,8 @@ def test_actual_get_item(
         "rule": {
             "match": "contains",
             "query": "shoe",
+            "stem": False,
+            "synonyms": False,
         },
         "stop_processing": True,
     }
@@ -218,6 +223,8 @@ async def test_actual_retrieve_async(
                 "rule": {
                     "match": "contains",
                     "query": "shoe",
+                    "stem": False,
+                    "synonyms": False,
                 },
                 "stop_processing": True,
             },
@@ -263,6 +270,8 @@ async def test_actual_list_items_async(
             "rule": {
                 "match": "contains",
                 "query": "shoe",
+                "stem": False,
+                "synonyms": False,
             },
             "stop_processing": True,
         },
@@ -295,6 +304,8 @@ async def test_actual_get_item_async(
         "rule": {
             "match": "contains",
             "query": "shoe",
+            "stem": False,
+            "synonyms": False,
         },
         "stop_processing": True,
     }

--- a/tests/curation_sets_test.py
+++ b/tests/curation_sets_test.py
@@ -87,6 +87,8 @@ def test_actual_upsert(
                 "rule": {
                     "match": "contains",
                     "query": "shoe",
+                    "stem": False,
+                    "synonyms": False,
                 },
                 "stop_processing": True,
             },
@@ -150,6 +152,8 @@ async def test_actual_upsert_async(
                 "rule": {
                     "match": "contains",
                     "query": "shoe",
+                    "stem": False,
+                    "synonyms": False,
                 },
                 "stop_processing": True,
             },


### PR DESCRIPTION
## Change Summary
Update types, test assertions and ci version of Typesense server for v30.2

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
